### PR TITLE
Refactor home feed limit parameter handling for improved clarity

### DIFF
--- a/src/routes/api/home-feed/+server.ts
+++ b/src/routes/api/home-feed/+server.ts
@@ -28,7 +28,9 @@ export const GET: RequestHandler = async (event) => {
 	const cursor = url.searchParams.get('cursor') ?? undefined;
 	const requested_view = url.searchParams.get('view');
 	const default_limit = requested_view === 'grid' ? HOME_FEED_GRID_PAGE_SIZE : HOME_FEED_PAGE_SIZE;
-	const requested_limit = Number(url.searchParams.get('limit') ?? default_limit);
+	const raw_limit = url.searchParams.get('limit');
+	const parsed_limit = raw_limit !== null ? parseInt(raw_limit, 10) : default_limit;
+	const requested_limit = Number.isFinite(parsed_limit) ? parsed_limit : default_limit;
 	const page = await get_home_feed_page(requested_limit, cursor);
 
 	return json(page);

--- a/src/routes/api/home-feed/+server.ts
+++ b/src/routes/api/home-feed/+server.ts
@@ -28,9 +28,10 @@ export const GET: RequestHandler = async (event) => {
 	const cursor = url.searchParams.get('cursor') ?? undefined;
 	const requested_view = url.searchParams.get('view');
 	const default_limit = requested_view === 'grid' ? HOME_FEED_GRID_PAGE_SIZE : HOME_FEED_PAGE_SIZE;
+	const MAX_LIMIT = 100;
 	const raw_limit = url.searchParams.get('limit');
 	const parsed_limit = raw_limit !== null ? parseInt(raw_limit, 10) : default_limit;
-	const requested_limit = Number.isFinite(parsed_limit) ? parsed_limit : default_limit;
+	const requested_limit = Math.min(Math.max(parsed_limit || default_limit, 1), MAX_LIMIT);
 	const page = await get_home_feed_page(requested_limit, cursor);
 
 	return json(page);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the feed API's limit parameter: non-numeric or missing values now fall back to a sane default and the requested limit is clamped to a safe range (minimum 1, maximum 100) to prevent out-of-range requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->